### PR TITLE
Duplicate character prevention bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor
 coverage
 .phpunit.result.cache
 .php_cs.cache
+.vscode

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $codes = (new UniqueCodes())
     ->setLength(6)
     ->generate(1, 100);
 
-// Result: LQJCKZ (1), HYW4LQ (2), Y9GXLQ (3), ... , 9HKV4L (100)
+// Result: H2ZMLL (1), YST6LL (2), XMRGLL (3), ... , 9ZCDKL (100)
 ```
 
 ## Installation
@@ -103,7 +103,7 @@ $obfuscatedNumber = ($inputNumber * $primeNumber) % $maxPrimeNumber
 
 #### Encoding the obfuscated number
 
-In the next step, the obfuscated number is encoded to string. This is just a base conversion using division and modulo. If a character has been added to the encoded string, then that character is removed from the available character list for that code. This ensures a code never contains duplicate characters.
+In the next step, the obfuscated number is encoded to string. This is just a base conversion using division and modulo.
 
 ## Testing
 

--- a/src/UniqueCodes.php
+++ b/src/UniqueCodes.php
@@ -326,12 +326,6 @@ class UniqueCodes
      */
     protected function getMaximumUniqueCodes()
     {
-        $maxCombinations = 1;
-
-        for ($i = 0; $i < $this->length; $i++) {
-            $maxCombinations = $maxCombinations * (strlen($this->characters) - $i);
-        }
-
-        return $maxCombinations;
+        return pow(strlen($this->characters), $this->length);
     }
 }

--- a/src/UniqueCodes.php
+++ b/src/UniqueCodes.php
@@ -227,7 +227,6 @@ class UniqueCodes
             $digit = $number % strlen($characters);
 
             $string .= $characters[$digit];
-            $characters = strtr($characters, [$characters[$digit] => '']);
 
             $number = $number / strlen($characters);
         }

--- a/tests/UniqueCodesTest.php
+++ b/tests/UniqueCodesTest.php
@@ -74,6 +74,18 @@ class UniqueCodesTest extends TestCase
 
         $this->assertCount(98892, $codes);
         $this->assertCount(98892, array_unique($codes));
+
+        $codes = iterator_to_array(
+            (new UniqueCodes())
+                ->setPrime(13)
+                ->setMaxPrime(113)
+                ->setCharacters('ABCDE')
+                ->setLength(4)
+                ->generate(1, 112)
+        );
+
+        $this->assertCount(112, $codes);
+        $this->assertCount(112, array_unique($codes));
     }
 
     /** @test */

--- a/tests/UniqueCodesTest.php
+++ b/tests/UniqueCodesTest.php
@@ -121,24 +121,6 @@ class UniqueCodesTest extends TestCase
     }
 
     /** @test */
-    public function it_generates_codes_without_duplicate_characters()
-    {
-        $codes = iterator_to_array(
-            (new UniqueCodes())
-                ->setPrime(17)
-                ->setMaxPrime(101)
-                ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-                ->setLength(6)
-                ->generate(1, 100)
-        );
-
-        foreach ($codes as $code) {
-            $this->assertEquals(6, strlen($code));
-            $this->assertCount(6, array_unique(str_split($code)));
-        }
-    }
-
-    /** @test */
     public function it_generates_codes_that_only_contain_characters_from_specified_character_list()
     {
         $codes = iterator_to_array(
@@ -172,7 +154,6 @@ class UniqueCodesTest extends TestCase
 
         foreach ($codes as $code) {
             $this->assertEquals(6, strlen($code));
-            $this->assertCount(6, array_unique(str_split($code)));
             $this->assertCount(0, array_diff(str_split($code), $characters));
         }
     }


### PR DESCRIPTION
The encoding process prevented duplicate characters in the output string. This meant it removed every used character from the character list. This causes certain numbers to have the same encoding result. This PR removes that logic, so each number is encoded correctly.

If you already use this package, this means every generated unique-code will change. By changing the encoding logic, the encoded result of each number will change, which can create collisions with older encoded numbers. **You must change the length of all new codes**, as this ensures every newly generated unique-code will never collide with older unique-codes.