### PR TITLE
Bugfixes and changes for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ use NextApps\UniqueCodes\UniqueCodes;
 
 // Generate 100 unique codes for numbers 1 to 100
 $codes = (new UniqueCodes())
-    ->setPrime(184259)
+    ->setObfuscatingPrime(9006077)
     ->setMaxPrime(7230323)
-    ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    ->setCharacters('LQJCKZMWDPTSXRGANYVBHF')
     ->setLength(6)
     ->generate(1, 100);
 
-// Result: H2ZMLL (1), YST6LL (2), XMRGLL (3), ... , 9ZCDKL (100)
+// Result: LWXNHJ (1), LACSVK (2), QLNMNM (3), ... , LYMJHL (100), QJVBVJ (101), LQXGQC (102), ... , LJQ5DJ (7230320), LC17CS (7230321), LZ8J8H (7230322)
 ```
 
 ## Installation
@@ -28,6 +28,7 @@ You can install the package via composer:
 ```bash
 composer require nextapps/unique-codes
 ```
+> Do not use v1 of this package, as it contains bugs. If you currently use v1, you should upgrade to v2 (Read the upgrading guide!).
 
 ## Usage
 
@@ -51,19 +52,19 @@ If a lot of codes need to be generated at the same time, it can cause a lot of m
 ### Setters
 
 Certain setters are required to generate unique codes:
-* `setPrime()`
+* `setObfuscatingPrime()`
 * `setMaxPrime()`
 * `setCharacters()`
 * `setLength()`
 
-#### setPrime($number)
+#### setObfuscatingPrime($number)
 
-This prime number is used to obfuscate a number between 1 and the max prime number.
+This prime number is used to obfuscate a number between 1 and the max prime number. This prime number must be bigger than your max prime number (which you provide to the `setMaxPrime` method).
 
 #### setMaxPrime($number)
 
 The max prime determines the maximum amount of unique codes you can generate. If you provide `101`, then you can generate codes from 1 to 100.
-This prime number must be bigger than the prime number you provide to the `setPrime` method.
+This prime number must be smaller than the prime number you provide to the `setObfuscatingPrime` method.
 
 #### setCharacters($string)
 
@@ -95,10 +96,10 @@ The code generation consists of 2 steps:
 
 If you encode sequential numbers, you will still see that the encoded strings are sequential. To remove the sequential nature, we use 'modular multiplicative inverse'.
 
-You define the upper limit of your range. This determines the maximum number you can obfuscate. Then every number is mapped to a unique obfuscated number between 1 and the upper limit. You multiply the input number with a random prime number, and you determine the remainder of the division of your multiplied input number by the upper limit of the range.
+You define the upper limit of your range. This determines the maximum number you can obfuscate. Then every number is mapped to a unique obfuscated number between 1 and the upper limit. You multiply the input number with a random (larger) prime number, and you determine the remainder of the division of your multiplied input number by the upper limit of the range.
 
 ```
-$obfuscatedNumber = ($inputNumber * $primeNumber) % $maxPrimeNumber
+$obfuscatedNumber = ($inputNumber * $obfuscatingPrimeNumber) % $maxPrimeNumber
 ```
 
 #### Encoding the obfuscated number

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,7 @@
+# Upgrading
+
+## From v1 to v2
+
+- The `setPrime` method has been renamed to `setObfuscatingPrime'`. The number you provide to this method should also be larger than the prime number you provide to the `setMaxPrime` number.
+- You should change the code length you use (if you can not regenerate all the codes you created in v1). If you generate code using a number in v2 you will not receive the same code as in v1. This means there could be collisions between your v1 and v2 codes. Changing the code length of your v2 codes will prevent such collisions.
+- The encoding mechanism in v1 could sometimes generate duplicates because it tried to prevent duplicate characters in the encoded result. This logic has been removed, which also means that codes will now contain duplicate characters. If you don't want that, you could always just skip the numbers that are converted in a unique code with duplicate characters.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,4 +26,7 @@
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>
+    <php>
+        <ini name="memory_limit" value="-1" />
+    </php>
 </phpunit>

--- a/src/UniqueCodes.php
+++ b/src/UniqueCodes.php
@@ -11,7 +11,7 @@ class UniqueCodes
      *
      * @var int
      */
-    protected $prime;
+    protected $obfuscatingPrime;
 
     /**
      * The prime number that is one larger than the maximum number that can be converted to a code.
@@ -63,15 +63,15 @@ class UniqueCodes
     protected $length;
 
     /**
-     * Set the prime number.
+     * Set the obfuscating prime number.
      *
      * @param int $prime
      *
      * @return self
      */
-    public function setPrime(int $prime)
+    public function setObfuscatingPrime(int $obfuscatingPrime)
     {
-        $this->prime = $prime;
+        $this->obfuscatingPrime = $obfuscatingPrime;
 
         return $this;
     }
@@ -208,7 +208,7 @@ class UniqueCodes
      */
     protected function obfuscateNumber(int $number)
     {
-        return ($number * $this->prime) % $this->maxPrime;
+        return ($number * $this->obfuscatingPrime) % $this->maxPrime;
     }
 
     /**
@@ -226,10 +226,17 @@ class UniqueCodes
         for ($i = 0; $i < $this->length; $i++) {
             $digit = $number % strlen($characters);
 
-            $string .= $characters[$digit];
+            $string = $characters[$digit] . $string;
 
             $number = $number / strlen($characters);
         }
+
+    //     $to_len = strlen($to_alphabet);
+    // $result = '';
+    // while ($base10_value != '0') {
+    //     $result = $to_base_chars[bcmod($base10_value, $to_len)] . $result;
+    //     $base10_value = bcdiv($base10_value, $to_len, 0);
+    // }
 
         return $string;
     }
@@ -274,7 +281,7 @@ class UniqueCodes
      */
     protected function validateInput(int $start, int $end = null)
     {
-        if (empty($this->prime)) {
+        if (empty($this->obfuscatingPrime)) {
             throw new RuntimeException('Prime number must be specified');
         }
 
@@ -290,9 +297,9 @@ class UniqueCodes
             throw new RuntimeException('Length must be specified');
         }
 
-        if ($this->prime >= $this->maxPrime) {
-            throw new RuntimeException('Prime number must be smaller than the max prime number');
-        }
+        // if ($this->prime >= $this->maxPrime) {
+        //     throw new RuntimeException('Prime number must be smaller than the max prime number');
+        // }
 
         if (strlen($this->characters) <= $this->length) {
             throw new RuntimeException(

--- a/src/UniqueCodes.php
+++ b/src/UniqueCodes.php
@@ -226,7 +226,7 @@ class UniqueCodes
         for ($i = 0; $i < $this->length; $i++) {
             $digit = $number % strlen($characters);
 
-            $string = $characters[$digit] . $string;
+            $string = $characters[$digit].$string;
 
             $number = $number / strlen($characters);
         }

--- a/src/UniqueCodes.php
+++ b/src/UniqueCodes.php
@@ -282,7 +282,7 @@ class UniqueCodes
     protected function validateInput(int $start, int $end = null)
     {
         if (empty($this->obfuscatingPrime)) {
-            throw new RuntimeException('Prime number must be specified');
+            throw new RuntimeException('Obfuscating prime number must be specified');
         }
 
         if (empty($this->maxPrime)) {
@@ -297,14 +297,8 @@ class UniqueCodes
             throw new RuntimeException('Length must be specified');
         }
 
-        // if ($this->prime >= $this->maxPrime) {
-        //     throw new RuntimeException('Prime number must be smaller than the max prime number');
-        // }
-
-        if (strlen($this->characters) <= $this->length) {
-            throw new RuntimeException(
-                'The size of the character list must be bigger or equal to the length of the code'
-            );
+        if ($this->obfuscatingPrime <= $this->maxPrime) {
+            throw new RuntimeException('Obfuscating prime number must be larger than the max prime number');
         }
 
         if (count(array_unique(str_split($this->characters))) !== strlen($this->characters)) {

--- a/src/UniqueCodes.php
+++ b/src/UniqueCodes.php
@@ -231,13 +231,6 @@ class UniqueCodes
             $number = $number / strlen($characters);
         }
 
-    //     $to_len = strlen($to_alphabet);
-    // $result = '';
-    // while ($base10_value != '0') {
-    //     $result = $to_base_chars[bcmod($base10_value, $to_len)] . $result;
-    //     $base10_value = bcdiv($base10_value, $to_len, 0);
-    // }
-
         return $string;
     }
 

--- a/tests/UniqueCodesTest.php
+++ b/tests/UniqueCodesTest.php
@@ -2,462 +2,592 @@
 
 namespace NextApps\UniqueCodes\Tests;
 
-use Generator;
-use NextApps\UniqueCodes\UniqueCodes;
+use ReflectionClass;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use NextApps\UniqueCodes\UniqueCodes;
 
 class UniqueCodesTest extends TestCase
 {
-    /** @test */
-    public function it_returns_generator_by_default()
+    /**
+     * @test
+     * @dataProvider uniqueCodesProvider
+     */
+    public function it_generates_unique_codes($maxPrime, $obfuscatingPrime, $obfuscatingPrimeMultiplicativeInverse, $length, $characters)
     {
-        $codes = (new UniqueCodes())
-            ->setPrime(17)
-            ->setMaxPrime(101)
-            ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-            ->setLength(6)
-            ->generate(1, 100);
+        $uniqueCodes = (new UniqueCodes())
+            ->setObfuscatingPrime($obfuscatingPrime)
+            ->setMaxPrime($maxPrime)
+            ->setCharacters($characters)
+            ->setLength($length)
+            ->generate(1, $maxPrime - 1, true);
 
-        $this->assertInstanceOf(Generator::class, $codes);
-    }
+        $this->assertCount($maxPrime - 1, $uniqueCodes);
+        $this->assertCount($maxPrime - 1, array_unique($uniqueCodes));
 
-    /** @test */
-    public function it_returns_array_if_requested()
-    {
-        $codes = (new UniqueCodes())
-            ->setPrime(17)
-            ->setMaxPrime(101)
-            ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-            ->setLength(6)
-            ->generate(1, 100, true);
+        foreach ($uniqueCodes as $index => $code) {
+            $obfuscatedNumber = $this->decode($code, $characters);
 
-        $this->assertIsArray($codes);
-    }
-
-    /** @test */
-    public function it_returns_string_if_no_end_provided()
-    {
-        $code = (new UniqueCodes())
-            ->setPrime(17)
-            ->setMaxPrime(101)
-            ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-            ->setLength(6)
-            ->generate(100);
-
-        $this->assertIsString($code);
-    }
-
-    /** @test */
-    public function it_generates_unique_codes()
-    {
-        $codes = iterator_to_array(
-            (new UniqueCodes())
-                ->setPrime(17)
-                ->setMaxPrime(101)
-                ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-                ->setLength(6)
-                ->generate(1, 100)
-        );
-
-        $this->assertCount(100, $codes);
-        $this->assertCount(100, array_unique($codes));
-
-        $codes = iterator_to_array(
-            (new UniqueCodes())
-                ->setPrime(30983)
-                ->setMaxPrime(98893)
-                ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-                ->setLength(6)
-                ->generate(1, 98892)
-        );
-
-        $this->assertCount(98892, $codes);
-        $this->assertCount(98892, array_unique($codes));
-
-        $codes = iterator_to_array(
-            (new UniqueCodes())
-                ->setPrime(13)
-                ->setMaxPrime(113)
-                ->setCharacters('ABCDE')
-                ->setLength(4)
-                ->generate(1, 112)
-        );
-
-        $this->assertCount(112, $codes);
-        $this->assertCount(112, array_unique($codes));
-    }
-
-    /** @test */
-    public function it_generates_unique_codes_within_range()
-    {
-        $codes = iterator_to_array(
-            (new UniqueCodes())
-                ->setPrime(17)
-                ->setMaxPrime(101)
-                ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-                ->setLength(6)
-                ->generate(25, 75)
-        );
-
-        $this->assertCount(51, $codes);
-        $this->assertCount(51, array_unique($codes));
-    }
-
-    /** @test */
-    public function it_generates_one_unique_code()
-    {
-        $codes = iterator_to_array(
-            (new UniqueCodes())
-                ->setPrime(17)
-                ->setMaxPrime(101)
-                ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-                ->setLength(6)
-                ->generate(25, 25)
-        );
-
-        $this->assertCount(1, $codes);
-        $this->assertCount(1, array_unique($codes));
-    }
-
-    /** @test */
-    public function it_generates_codes_that_only_contain_characters_from_specified_character_list()
-    {
-        $codes = iterator_to_array(
-            (new UniqueCodes())
-                ->setPrime(17)
-                ->setMaxPrime(101)
-                ->setCharacters($characters = 'ABCDEFG')
-                ->setLength(6)
-                ->generate(1, 100)
-        );
-
-        foreach ($codes as $code) {
-            $this->assertEquals(6, strlen($code));
-            $this->assertCount(0, array_diff(str_split($code), str_split($characters)));
+            $this->assertEquals($index + 1, ($obfuscatedNumber * $obfuscatingPrimeMultiplicativeInverse) % $maxPrime);
         }
     }
 
-    /** @test */
-    public function it_generates_codes_with_character_list_array()
+    /**
+     * @return array
+     */
+    public function uniqueCodesProvider()
     {
-        $codes = iterator_to_array(
-            (new UniqueCodes())
-                ->setPrime(17)
-                ->setMaxPrime(101)
-                ->setCharacters($characters = ['A', 'B', 'C', 'D', 'E', 'F', 'G'])
-                ->setLength(6)
-                ->generate(1, 100)
-        );
+        return [
+            [101, 387420489, 47, 3, 'ABCDE'],
+        ];
+    }
 
-        $this->assertCount(100, array_unique($codes));
+    /**
+     * @test
+     * @dataProvider obfuscateNumbersProvider
+     */
+    public function it_obfuscates_numbers($maxPrime, $obfuscatingPrime, $obfuscatingPrimeMultiplicativeInverse, $number, $expectedObfuscatedNumber)
+    {
+        $uniqueCodes = (new UniqueCodes())->setObfuscatingPrime($obfuscatingPrime)->setMaxPrime($maxPrime);
 
-        foreach ($codes as $code) {
-            $this->assertEquals(6, strlen($code));
-            $this->assertCount(0, array_diff(str_split($code), $characters));
+        $class = new ReflectionClass($uniqueCodes);
+        $method = $class->getMethod('obfuscateNumber');
+        $method->setAccessible(true);
+
+        $this->assertEquals($expectedObfuscatedNumber, $obfuscatedNumber = $method->invokeArgs($uniqueCodes, [$number]));
+        $this->assertEquals($number, ($obfuscatedNumber * $obfuscatingPrimeMultiplicativeInverse) % $maxPrime);
+    }
+
+    /**
+     * @return array
+     */
+    public function obfuscateNumbersProvider()
+    {
+        return [
+            [101, 387420489, 47, 1, 43],
+            [101, 387420489, 47, 2, 86],
+            [101, 387420489, 47, 3, 28],
+            [101, 387420489, 47, 4, 71],
+            [101, 387420489, 47, 5, 13],
+            [101, 387420489, 47, 6, 56],
+            [101, 387420489, 47, 7, 99],
+            [101, 387420489, 47, 8, 41],
+            [101, 387420489, 47, 9, 84],
+            [101, 387420489, 47, 10, 26],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider encodeNumbersProvider
+     */
+    public function it_encodes_numbers($start, $end, $length, $characters)
+    {
+        $uniqueCodes = (new UniqueCodes())->setLength($length)->setCharacters($characters);
+
+        $class = new ReflectionClass($uniqueCodes);
+        $method = $class->getMethod('encodeNumber');
+        $method->setAccessible(true);
+
+        $result = [];
+        for ($i = $start; $i <= $end; $i++) {
+            $string = $method->invokeArgs($uniqueCodes, [$i]);
+
+            $this->assertEquals($i, $this->decode($string, $characters));
+
+            $result[] = $string;
         }
+
+        $this->assertCount($end - $start + 1, $result);
+        $this->assertCount($end - $start + 1, array_unique($result));
+        $this->assertEquals(0, $this->decode($string, $method->invokeArgs($uniqueCodes, [$end + 1])));
     }
 
-    /** @test */
-    public function it_generates_codes_with_prefix()
+    /**
+     * @return array
+     */
+    public function encodeNumbersProvider()
     {
-        $codes = iterator_to_array(
-            (new UniqueCodes())
-                ->setPrime(17)
-                ->setMaxPrime(101)
-                ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-                ->setLength(6)
-                ->setPrefix('TEST')
-                ->generate(1, 100)
-        );
+        return [
+            [1, 1295, 4, 'ABCDEF'],
+            [1, 531440, 6, 'ABCDEFGHI'],
+            [1, 1419856, 5, 'ABCDEFGHIJLKMNOPQ'],
+        ];
+    }
 
-        $this->assertCount(100, array_unique($codes));
+    /**
+     * Decode string to base10 number.
+     *
+     * @param string $string
+     * @param string $alphabet
+     *
+     * @return int
+     */
+    public function decode(string $value, string $alphabet)
+    {
+        $digits = str_split($value);
+        $stringLength = strlen($value);
 
-        foreach ($codes as $code) {
-            $this->assertEquals(10, strlen($code));
-            $this->assertEquals('TEST', substr($code, 0, 4));
+        $characters = str_split($alphabet);
+        $alphabetLength = strlen($alphabet);
+
+        $result = 0;
+
+        for ($i = 1; $i <= $stringLength; $i++) {
+            $result += (array_search($digits[$i-1], $characters) * bcpow(strlen($alphabet), strlen($value) - $i));
         }
+
+        return $result;
     }
 
-    /** @test */
-    public function it_generates_codes_with_suffix()
-    {
-        $codes = iterator_to_array(
-            (new UniqueCodes())
-                ->setPrime(17)
-                ->setMaxPrime(101)
-                ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-                ->setLength(6)
-                ->setSuffix('TEST')
-                ->generate(1, 100)
-        );
+    // /** @test */
+    // public function it_returns_generator_by_default()
+    // {
+    //     $codes = (new UniqueCodes())
+    //         ->setPrime(17)
+    //         ->setMaxPrime(101)
+    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //         ->setLength(6)
+    //         ->generate(1, 100);
 
-        $this->assertCount(100, array_unique($codes));
+    //     $this->assertInstanceOf(Generator::class, $codes);
+    // }
 
-        foreach ($codes as $code) {
-            $this->assertEquals(10, strlen($code));
-            $this->assertEquals('TEST', substr($code, 6, 4));
-        }
-    }
+    // /** @test */
+    // public function it_returns_array_if_requested()
+    // {
+    //     $codes = (new UniqueCodes())
+    //         ->setPrime(17)
+    //         ->setMaxPrime(101)
+    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //         ->setLength(6)
+    //         ->generate(1, 100, true);
 
-    /** @test */
-    public function it_generates_codes_with_prefix_and_suffix()
-    {
-        $codes = iterator_to_array(
-            (new UniqueCodes())
-                ->setPrime(17)
-                ->setMaxPrime(101)
-                ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-                ->setLength(6)
-                ->setPrefix('PREFIX')
-                ->setSuffix('SUFFIX')
-                ->generate(1, 100)
-        );
+    //     $this->assertIsArray($codes);
+    // }
 
-        $this->assertCount(100, array_unique($codes));
+    // /** @test */
+    // public function it_returns_string_if_no_end_provided()
+    // {
+    //     $code = (new UniqueCodes())
+    //         ->setPrime(17)
+    //         ->setMaxPrime(101)
+    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //         ->setLength(6)
+    //         ->generate(100);
 
-        foreach ($codes as $code) {
-            $this->assertEquals(18, strlen($code));
-            $this->assertEquals('PREFIX', substr($code, 0, 6));
-            $this->assertEquals('SUFFIX', substr($code, 12, 6));
-        }
-    }
+    //     $this->assertIsString($code);
+    // }
 
-    /** @test */
-    public function it_generates_codes_with_delimiter()
-    {
-        $codes = iterator_to_array(
-            (new UniqueCodes())
-                ->setPrime(17)
-                ->setMaxPrime(101)
-                ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-                ->setLength(6)
-                ->setDelimiter('-', 3)
-                ->generate(1, 100)
-        );
+    // /** @test */
+    // public function it_generates_unique_codes()
+    // {
+    //     $codes = iterator_to_array(
+    //         (new UniqueCodes())
+    //             ->setPrime(17)
+    //             ->setMaxPrime(101)
+    //             ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //             ->setLength(6)
+    //             ->generate(1, 100)
+    //     );
 
-        $this->assertCount(100, array_unique($codes));
+    //     $this->assertCount(100, $codes);
+    //     $this->assertCount(100, array_unique($codes));
 
-        foreach ($codes as $code) {
-            $this->assertEquals(7, strlen($code));
-            $this->assertEquals('-', substr($code, 3, 1));
-        }
-    }
+    //     $codes = iterator_to_array(
+    //         (new UniqueCodes())
+    //             ->setPrime(30983)
+    //             ->setMaxPrime(98893)
+    //             ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //             ->setLength(6)
+    //             ->generate(1, 98892)
+    //     );
 
-    /** @test */
-    public function it_generates_codes_with_suffix_and_prefix_and_delimiter()
-    {
-        $codes = iterator_to_array(
-            (new UniqueCodes())
-                ->setPrime(17)
-                ->setMaxPrime(101)
-                ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-                ->setLength(6)
-                ->setPrefix('PREFIX')
-                ->setSuffix('SUFFIX')
-                ->setDelimiter('-', 3)
-                ->generate(1, 100)
-        );
+    //     $this->assertCount(98892, $codes);
+    //     $this->assertCount(98892, array_unique($codes));
 
-        $this->assertCount(100, array_unique($codes));
+    //     $codes = iterator_to_array(
+    //         (new UniqueCodes())
+    //             ->setPrime(13)
+    //             ->setMaxPrime(113)
+    //             ->setCharacters('ABCDE')
+    //             ->setLength(4)
+    //             ->generate(1, 112)
+    //     );
 
-        foreach ($codes as $code) {
-            $this->assertEquals(21, strlen($code));
-            $this->assertEquals('PREFIX-', substr($code, 0, 7));
-            $this->assertEquals('-', substr($code, 10, 1));
-            $this->assertEquals('-SUFFIX', substr($code, 14, 7));
-        }
-    }
+    //     $this->assertCount(112, $codes);
+    //     $this->assertCount(112, array_unique($codes));
+    // }
 
-    /** @test */
-    public function it_throws_exception_if_prime_is_not_specified()
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Prime number must be specified');
+    // /** @test */
+    // public function it_generates_unique_codes_within_range()
+    // {
+    //     $codes = iterator_to_array(
+    //         (new UniqueCodes())
+    //             ->setPrime(17)
+    //             ->setMaxPrime(101)
+    //             ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //             ->setLength(6)
+    //             ->generate(25, 75)
+    //     );
 
-        (new UniqueCodes())
-            ->setMaxPrime(101)
-            ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-            ->setLength(6)
-            ->generate(1, 100);
-    }
+    //     $this->assertCount(51, $codes);
+    //     $this->assertCount(51, array_unique($codes));
+    // }
 
-    /** @test */
-    public function it_throws_exception_if_max_prime_is_not_specified()
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Max prime number must be specified');
+    // /** @test */
+    // public function it_generates_one_unique_code()
+    // {
+    //     $codes = iterator_to_array(
+    //         (new UniqueCodes())
+    //             ->setPrime(17)
+    //             ->setMaxPrime(101)
+    //             ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //             ->setLength(6)
+    //             ->generate(25, 25)
+    //     );
 
-        (new UniqueCodes())
-            ->setPrime(17)
-            ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-            ->setLength(6)
-            ->generate(1, 100);
-    }
+    //     $this->assertCount(1, $codes);
+    //     $this->assertCount(1, array_unique($codes));
+    // }
 
-    /** @test */
-    public function it_throws_exception_if_characters_are_not_specified()
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Character list must be specified');
+    // /** @test */
+    // public function it_generates_codes_that_only_contain_characters_from_specified_character_list()
+    // {
+    //     $codes = iterator_to_array(
+    //         (new UniqueCodes())
+    //             ->setPrime(17)
+    //             ->setMaxPrime(101)
+    //             ->setCharacters($characters = 'ABCDEFG')
+    //             ->setLength(6)
+    //             ->generate(1, 100)
+    //     );
 
-        (new UniqueCodes())
-            ->setPrime(17)
-            ->setMaxPrime(101)
-            ->setLength(6)
-            ->generate(1, 100);
-    }
+    //     foreach ($codes as $code) {
+    //         $this->assertEquals(6, strlen($code));
+    //         $this->assertCount(0, array_diff(str_split($code), str_split($characters)));
+    //     }
+    // }
 
-    /** @test */
-    public function it_throws_exception_if_length_is_not_specified()
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Length must be specified');
+    // /** @test */
+    // public function it_generates_codes_with_character_list_array()
+    // {
+    //     $codes = iterator_to_array(
+    //         (new UniqueCodes())
+    //             ->setPrime(17)
+    //             ->setMaxPrime(101)
+    //             ->setCharacters($characters = ['A', 'B', 'C', 'D', 'E', 'F', 'G'])
+    //             ->setLength(6)
+    //             ->generate(1, 100)
+    //     );
 
-        (new UniqueCodes())
-            ->setPrime(17)
-            ->setMaxPrime(101)
-            ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-            ->generate(1, 100);
-    }
+    //     $this->assertCount(100, array_unique($codes));
 
-    /** @test */
-    public function it_throws_exception_if_prime_number_is_bigger_than_max_prime_number()
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Prime number must be smaller than the max prime number');
+    //     foreach ($codes as $code) {
+    //         $this->assertEquals(6, strlen($code));
+    //         $this->assertCount(0, array_diff(str_split($code), $characters));
+    //     }
+    // }
 
-        (new UniqueCodes())
-            ->setPrime(101)
-            ->setMaxPrime(17)
-            ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-            ->setLength(6)
-            ->generate(1, 100);
-    }
+    // /** @test */
+    // public function it_generates_codes_with_prefix()
+    // {
+    //     $codes = iterator_to_array(
+    //         (new UniqueCodes())
+    //             ->setPrime(17)
+    //             ->setMaxPrime(101)
+    //             ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //             ->setLength(6)
+    //             ->setPrefix('TEST')
+    //             ->generate(1, 100)
+    //     );
 
-    /** @test */
-    public function it_throws_exception_if_prime_number_is_equal_to_max_prime_number()
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Prime number must be smaller than the max prime number');
+    //     $this->assertCount(100, array_unique($codes));
 
-        (new UniqueCodes())
-            ->setPrime(101)
-            ->setMaxPrime(101)
-            ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-            ->setLength(6)
-            ->generate(1, 100);
-    }
+    //     foreach ($codes as $code) {
+    //         $this->assertEquals(10, strlen($code));
+    //         $this->assertEquals('TEST', substr($code, 0, 4));
+    //     }
+    // }
 
-    /** @test */
-    public function it_throws_exception_if_size_of_character_list_is_smaller_than_specified_code_length()
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The size of the character list must be bigger or equal to the length of the code');
+    // /** @test */
+    // public function it_generates_codes_with_suffix()
+    // {
+    //     $codes = iterator_to_array(
+    //         (new UniqueCodes())
+    //             ->setPrime(17)
+    //             ->setMaxPrime(101)
+    //             ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //             ->setLength(6)
+    //             ->setSuffix('TEST')
+    //             ->generate(1, 100)
+    //     );
 
-        (new UniqueCodes())
-            ->setPrime(17)
-            ->setMaxPrime(101)
-            ->setCharacters('LQJCK')
-            ->setLength(6)
-            ->generate(1, 100);
-    }
+    //     $this->assertCount(100, array_unique($codes));
 
-    /** @test */
-    public function it_throws_exception_if_size_of_character_list_equals_specified_code_length()
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The size of the character list must be bigger or equal to the length of the code');
+    //     foreach ($codes as $code) {
+    //         $this->assertEquals(10, strlen($code));
+    //         $this->assertEquals('TEST', substr($code, 6, 4));
+    //     }
+    // }
 
-        (new UniqueCodes())
-            ->setPrime(17)
-            ->setMaxPrime(101)
-            ->setCharacters('LQJCKZ')
-            ->setLength(6)
-            ->generate(1, 100);
-    }
+    // /** @test */
+    // public function it_generates_codes_with_prefix_and_suffix()
+    // {
+    //     $codes = iterator_to_array(
+    //         (new UniqueCodes())
+    //             ->setPrime(17)
+    //             ->setMaxPrime(101)
+    //             ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //             ->setLength(6)
+    //             ->setPrefix('PREFIX')
+    //             ->setSuffix('SUFFIX')
+    //             ->generate(1, 100)
+    //     );
 
-    /** @test */
-    public function it_throws_exception_if_character_list_contains_duplicates()
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The character list can not contain duplicates');
+    //     $this->assertCount(100, array_unique($codes));
 
-        (new UniqueCodes())
-            ->setPrime(17)
-            ->setMaxPrime(101)
-            ->setCharacters('LQJCKZL')
-            ->setLength(6)
-            ->generate(1, 100);
-    }
+    //     foreach ($codes as $code) {
+    //         $this->assertEquals(18, strlen($code));
+    //         $this->assertEquals('PREFIX', substr($code, 0, 6));
+    //         $this->assertEquals('SUFFIX', substr($code, 12, 6));
+    //     }
+    // }
 
-    /** @test */
-    public function it_throws_exception_if_max_prime_number_is_too_big_for_the_specified_character_list_and_code_length()
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The length of the code is too short or the character list is too small to create the number of unique codes equal to the max prime number');
+    // /** @test */
+    // public function it_generates_codes_with_delimiter()
+    // {
+    //     $codes = iterator_to_array(
+    //         (new UniqueCodes())
+    //             ->setPrime(17)
+    //             ->setMaxPrime(101)
+    //             ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //             ->setLength(6)
+    //             ->setDelimiter('-', 3)
+    //             ->generate(1, 100)
+    //     );
 
-        (new UniqueCodes())
-            ->setPrime(17)
-            ->setMaxPrime(101)
-            ->setCharacters('LQJC')
-            ->setLength(3)
-            ->generate(1, 100);
-    }
+    //     $this->assertCount(100, array_unique($codes));
 
-    /** @test */
-    public function it_throws_exception_if_start_is_less_than_zero()
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The start number must be bigger than zero');
+    //     foreach ($codes as $code) {
+    //         $this->assertEquals(7, strlen($code));
+    //         $this->assertEquals('-', substr($code, 3, 1));
+    //     }
+    // }
 
-        (new UniqueCodes())
-            ->setPrime(17)
-            ->setMaxPrime(101)
-            ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-            ->setLength(6)
-            ->generate(-1, 100);
-    }
+    // /** @test */
+    // public function it_generates_codes_with_suffix_and_prefix_and_delimiter()
+    // {
+    //     $codes = iterator_to_array(
+    //         (new UniqueCodes())
+    //             ->setPrime(17)
+    //             ->setMaxPrime(101)
+    //             ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //             ->setLength(6)
+    //             ->setPrefix('PREFIX')
+    //             ->setSuffix('SUFFIX')
+    //             ->setDelimiter('-', 3)
+    //             ->generate(1, 100)
+    //     );
 
-    /** @test */
-    public function it_throws_exception_if_start_equals_zero()
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The start number must be bigger than zero');
+    //     $this->assertCount(100, array_unique($codes));
 
-        (new UniqueCodes())
-            ->setPrime(17)
-            ->setMaxPrime(101)
-            ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-            ->setLength(6)
-            ->generate(0, 100);
-    }
+    //     foreach ($codes as $code) {
+    //         $this->assertEquals(21, strlen($code));
+    //         $this->assertEquals('PREFIX-', substr($code, 0, 7));
+    //         $this->assertEquals('-', substr($code, 10, 1));
+    //         $this->assertEquals('-SUFFIX', substr($code, 14, 7));
+    //     }
+    // }
 
-    /** @test */
-    public function it_throws_exception_if_end_is_bigger_than_max_prime_number()
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The end number can not be bigger or equal to the max prime number');
+    // /** @test */
+    // public function it_throws_exception_if_prime_is_not_specified()
+    // {
+    //     $this->expectException(RuntimeException::class);
+    //     $this->expectExceptionMessage('Prime number must be specified');
 
-        (new UniqueCodes())
-            ->setPrime(17)
-            ->setMaxPrime(101)
-            ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-            ->setLength(6)
-            ->generate(50, 150);
-    }
+    //     (new UniqueCodes())
+    //         ->setMaxPrime(101)
+    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //         ->setLength(6)
+    //         ->generate(1, 100);
+    // }
 
-    /** @test */
-    public function it_throws_exception_if_end_equals_max_prime_number()
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The end number can not be bigger or equal to the max prime number');
+    // /** @test */
+    // public function it_throws_exception_if_max_prime_is_not_specified()
+    // {
+    //     $this->expectException(RuntimeException::class);
+    //     $this->expectExceptionMessage('Max prime number must be specified');
 
-        (new UniqueCodes())
-            ->setPrime(17)
-            ->setMaxPrime(101)
-            ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-            ->setLength(6)
-            ->generate(50, 101);
-    }
+    //     (new UniqueCodes())
+    //         ->setPrime(17)
+    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //         ->setLength(6)
+    //         ->generate(1, 100);
+    // }
+
+    // /** @test */
+    // public function it_throws_exception_if_characters_are_not_specified()
+    // {
+    //     $this->expectException(RuntimeException::class);
+    //     $this->expectExceptionMessage('Character list must be specified');
+
+    //     (new UniqueCodes())
+    //         ->setPrime(17)
+    //         ->setMaxPrime(101)
+    //         ->setLength(6)
+    //         ->generate(1, 100);
+    // }
+
+    // /** @test */
+    // public function it_throws_exception_if_length_is_not_specified()
+    // {
+    //     $this->expectException(RuntimeException::class);
+    //     $this->expectExceptionMessage('Length must be specified');
+
+    //     (new UniqueCodes())
+    //         ->setPrime(17)
+    //         ->setMaxPrime(101)
+    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //         ->generate(1, 100);
+    // }
+
+    // /** @test */
+    // public function it_throws_exception_if_prime_number_is_bigger_than_max_prime_number()
+    // {
+    //     $this->expectException(RuntimeException::class);
+    //     $this->expectExceptionMessage('Prime number must be smaller than the max prime number');
+
+    //     (new UniqueCodes())
+    //         ->setPrime(101)
+    //         ->setMaxPrime(17)
+    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //         ->setLength(6)
+    //         ->generate(1, 100);
+    // }
+
+    // /** @test */
+    // public function it_throws_exception_if_prime_number_is_equal_to_max_prime_number()
+    // {
+    //     $this->expectException(RuntimeException::class);
+    //     $this->expectExceptionMessage('Prime number must be smaller than the max prime number');
+
+    //     (new UniqueCodes())
+    //         ->setPrime(101)
+    //         ->setMaxPrime(101)
+    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //         ->setLength(6)
+    //         ->generate(1, 100);
+    // }
+
+    // /** @test */
+    // public function it_throws_exception_if_size_of_character_list_is_smaller_than_specified_code_length()
+    // {
+    //     $this->expectException(RuntimeException::class);
+    //     $this->expectExceptionMessage('The size of the character list must be bigger or equal to the length of the code');
+
+    //     (new UniqueCodes())
+    //         ->setPrime(17)
+    //         ->setMaxPrime(101)
+    //         ->setCharacters('LQJCK')
+    //         ->setLength(6)
+    //         ->generate(1, 100);
+    // }
+
+    // /** @test */
+    // public function it_throws_exception_if_size_of_character_list_equals_specified_code_length()
+    // {
+    //     $this->expectException(RuntimeException::class);
+    //     $this->expectExceptionMessage('The size of the character list must be bigger or equal to the length of the code');
+
+    //     (new UniqueCodes())
+    //         ->setPrime(17)
+    //         ->setMaxPrime(101)
+    //         ->setCharacters('LQJCKZ')
+    //         ->setLength(6)
+    //         ->generate(1, 100);
+    // }
+
+    // /** @test */
+    // public function it_throws_exception_if_character_list_contains_duplicates()
+    // {
+    //     $this->expectException(RuntimeException::class);
+    //     $this->expectExceptionMessage('The character list can not contain duplicates');
+
+    //     (new UniqueCodes())
+    //         ->setPrime(17)
+    //         ->setMaxPrime(101)
+    //         ->setCharacters('LQJCKZL')
+    //         ->setLength(6)
+    //         ->generate(1, 100);
+    // }
+
+    // /** @test */
+    // public function it_throws_exception_if_max_prime_number_is_too_big_for_the_specified_character_list_and_code_length()
+    // {
+    //     $this->expectException(RuntimeException::class);
+    //     $this->expectExceptionMessage('The length of the code is too short or the character list is too small to create the number of unique codes equal to the max prime number');
+
+    //     (new UniqueCodes())
+    //         ->setPrime(17)
+    //         ->setMaxPrime(101)
+    //         ->setCharacters('LQJC')
+    //         ->setLength(3)
+    //         ->generate(1, 100);
+    // }
+
+    // /** @test */
+    // public function it_throws_exception_if_start_is_less_than_zero()
+    // {
+    //     $this->expectException(RuntimeException::class);
+    //     $this->expectExceptionMessage('The start number must be bigger than zero');
+
+    //     (new UniqueCodes())
+    //         ->setPrime(17)
+    //         ->setMaxPrime(101)
+    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //         ->setLength(6)
+    //         ->generate(-1, 100);
+    // }
+
+    // /** @test */
+    // public function it_throws_exception_if_start_equals_zero()
+    // {
+    //     $this->expectException(RuntimeException::class);
+    //     $this->expectExceptionMessage('The start number must be bigger than zero');
+
+    //     (new UniqueCodes())
+    //         ->setPrime(17)
+    //         ->setMaxPrime(101)
+    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //         ->setLength(6)
+    //         ->generate(0, 100);
+    // }
+
+    // /** @test */
+    // public function it_throws_exception_if_end_is_bigger_than_max_prime_number()
+    // {
+    //     $this->expectException(RuntimeException::class);
+    //     $this->expectExceptionMessage('The end number can not be bigger or equal to the max prime number');
+
+    //     (new UniqueCodes())
+    //         ->setPrime(17)
+    //         ->setMaxPrime(101)
+    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //         ->setLength(6)
+    //         ->generate(50, 150);
+    // }
+
+    // /** @test */
+    // public function it_throws_exception_if_end_equals_max_prime_number()
+    // {
+    //     $this->expectException(RuntimeException::class);
+    //     $this->expectExceptionMessage('The end number can not be bigger or equal to the max prime number');
+
+    //     (new UniqueCodes())
+    //         ->setPrime(17)
+    //         ->setMaxPrime(101)
+    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
+    //         ->setLength(6)
+    //         ->generate(50, 101);
+    // }
 }

--- a/tests/UniqueCodesTest.php
+++ b/tests/UniqueCodesTest.php
@@ -3,10 +3,10 @@
 namespace NextApps\UniqueCodes\Tests;
 
 use Generator;
+use NextApps\UniqueCodes\UniqueCodes;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use RuntimeException;
-use PHPUnit\Framework\TestCase;
-use NextApps\UniqueCodes\UniqueCodes;
 
 class UniqueCodesTest extends TestCase
 {
@@ -44,7 +44,7 @@ class UniqueCodesTest extends TestCase
             [30983, 98893, 3925, 4, '123456ABCDEFGH'],
             [495563, 968197, 86214, 6, 'ABCDEFGHI'],
             [1340021, 6824473, 46234, 8, 'ABCDEF'],
-            [7230323, 9006077, 4263725, 6, 'LQJCKZMWDPTSXRGANYVBHF']
+            [7230323, 9006077, 4263725, 6, 'LQJCKZMWDPTSXRGANYVBHF'],
         ];
     }
 
@@ -140,7 +140,7 @@ class UniqueCodesTest extends TestCase
         $result = 0;
 
         for ($i = 1; $i <= $stringLength; $i++) {
-            $result += (array_search($digits[$i-1], $characters) * bcpow(strlen($alphabet), strlen($value) - $i));
+            $result += (array_search($digits[$i - 1], $characters) * bcpow(strlen($alphabet), strlen($value) - $i));
         }
 
         return $result;

--- a/tests/UniqueCodesTest.php
+++ b/tests/UniqueCodesTest.php
@@ -80,6 +80,51 @@ class UniqueCodesTest extends TestCase
             [101, 387420489, 47, 8, 41],
             [101, 387420489, 47, 9, 84],
             [101, 387420489, 47, 10, 26],
+            [495563, 968197, 86214, 1, 472634],
+            [495563, 968197, 86214, 2, 449705],
+            [495563, 968197, 86214, 3, 426776],
+            [495563, 968197, 86214, 4, 403847],
+            [495563, 968197, 86214, 5, 380918],
+            [495563, 968197, 86214, 6, 357989],
+            [495563, 968197, 86214, 7, 335060],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider obfuscateNumbersWithinRangeProvider
+     */
+    public function it_obfuscates_numbers_within_range($maxPrime, $obfuscatingPrime)
+    {
+        $uniqueCodes = (new UniqueCodes())->setObfuscatingPrime($obfuscatingPrime)->setMaxPrime($maxPrime);
+
+        $class = new ReflectionClass($uniqueCodes);
+        $method = $class->getMethod('obfuscateNumber');
+        $method->setAccessible(true);
+
+        $result = [];
+
+        for ($i = 1; $i < $maxPrime; $i++) {
+            $result[] = $method->invokeArgs($uniqueCodes, [$i]);
+        }
+
+        sort($result);
+        $this->assertEquals(range(1, $maxPrime - 1), $result);
+    }
+
+    /**
+     * @return array
+     */
+    public function obfuscateNumbersWithinRangeProvider()
+    {
+        return [
+            [101, 387420489],
+            [101, 191],
+            [30983, 98893],
+            [495563, 968197],
+            [1340021, 6824473],
+            [7230323, 9006077],
+            [495563, 968197],
         ];
     }
 
@@ -119,31 +164,6 @@ class UniqueCodesTest extends TestCase
             [1, 531440, 6, 'ABCDEFGHI'],
             [1, 1419856, 5, 'ABCDEFGHIJLKMNOPQ'],
         ];
-    }
-
-    /**
-     * Decode string to base10 number.
-     *
-     * @param string $string
-     * @param string $alphabet
-     *
-     * @return int
-     */
-    public function decode(string $value, string $alphabet)
-    {
-        $digits = str_split($value);
-        $stringLength = strlen($value);
-
-        $characters = str_split($alphabet);
-        $alphabetLength = strlen($alphabet);
-
-        $result = 0;
-
-        for ($i = 1; $i <= $stringLength; $i++) {
-            $result += (array_search($digits[$i - 1], $characters) * bcpow(strlen($alphabet), strlen($value) - $i));
-        }
-
-        return $result;
     }
 
     /** @test */
@@ -528,5 +548,27 @@ class UniqueCodesTest extends TestCase
             ->setCharacters('ABCDEFGHI')
             ->setLength(6)
             ->generate(50, 101);
+    }
+
+    /**
+     * Decode string to base10 number.
+     *
+     * @param string $string
+     * @param string $alphabet
+     *
+     * @return int
+     */
+    public function decode(string $value, string $alphabet)
+    {
+        $digits = str_split($value);
+        $characters = str_split($alphabet);
+
+        $result = 0;
+
+        for ($i = 1; $i <= strlen($value); $i++) {
+            $result += (array_search($digits[$i - 1], $characters) * bcpow(strlen($alphabet), strlen($value) - $i));
+        }
+
+        return $result;
     }
 }

--- a/tests/UniqueCodesTest.php
+++ b/tests/UniqueCodesTest.php
@@ -62,6 +62,9 @@ class UniqueCodesTest extends TestCase
 
         $this->assertEquals($expectedObfuscatedNumber, $obfuscatedNumber = $method->invokeArgs($uniqueCodes, [$number]));
         $this->assertEquals($number, ($obfuscatedNumber * $obfuscatingPrimeMultiplicativeInverse) % $maxPrime);
+
+        $this->assertEquals(0, $method->invokeArgs($uniqueCodes, [$maxPrime]));
+        $this->assertEquals($expectedObfuscatedNumber, $method->invokeArgs($uniqueCodes, [$number + $maxPrime]));
     }
 
     /**
@@ -87,6 +90,13 @@ class UniqueCodesTest extends TestCase
             [495563, 968197, 86214, 5, 380918],
             [495563, 968197, 86214, 6, 357989],
             [495563, 968197, 86214, 7, 335060],
+            [3469, 8311, 2471, 1, 1373],
+            [3469, 8311, 2471, 2, 2746],
+            [3469, 8311, 2471, 3, 650],
+            [3469, 8311, 2471, 4, 2023],
+            [3469, 8311, 2471, 5, 3396],
+            [3469, 8311, 2471, 6, 1300],
+            [3469, 8311, 2471, 7, 2673],
         ];
     }
 

--- a/tests/UniqueCodesTest.php
+++ b/tests/UniqueCodesTest.php
@@ -2,7 +2,9 @@
 
 namespace NextApps\UniqueCodes\Tests;
 
+use Generator;
 use ReflectionClass;
+use RuntimeException;
 use PHPUnit\Framework\TestCase;
 use NextApps\UniqueCodes\UniqueCodes;
 
@@ -38,6 +40,10 @@ class UniqueCodesTest extends TestCase
     {
         return [
             [101, 387420489, 47, 3, 'ABCDE'],
+            [101, 191, 55, 3, '12345'],
+            [30983, 98893, 3925, 4, '123456ABCDEFGH'],
+            [495563, 968197, 86214, 6, 'ABCDEFGHI'],
+            [1340021, 6824473, 46234, 8, 'ABCDEF'],
         ];
     }
 
@@ -139,455 +145,387 @@ class UniqueCodesTest extends TestCase
         return $result;
     }
 
-    // /** @test */
-    // public function it_returns_generator_by_default()
-    // {
-    //     $codes = (new UniqueCodes())
-    //         ->setPrime(17)
-    //         ->setMaxPrime(101)
-    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //         ->setLength(6)
-    //         ->generate(1, 100);
+    /** @test */
+    public function it_returns_generator_by_default()
+    {
+        $codes = (new UniqueCodes())
+            ->setObfuscatingPrime(191)
+            ->setMaxPrime(101)
+            ->setCharacters('ABCDEFGHI')
+            ->setLength(6)
+            ->generate(1, 100);
 
-    //     $this->assertInstanceOf(Generator::class, $codes);
-    // }
+        $this->assertInstanceOf(Generator::class, $codes);
+    }
 
-    // /** @test */
-    // public function it_returns_array_if_requested()
-    // {
-    //     $codes = (new UniqueCodes())
-    //         ->setPrime(17)
-    //         ->setMaxPrime(101)
-    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //         ->setLength(6)
-    //         ->generate(1, 100, true);
+    /** @test */
+    public function it_returns_array_if_requested()
+    {
+        $codes = (new UniqueCodes())
+            ->setObfuscatingPrime(191)
+            ->setMaxPrime(101)
+            ->setCharacters('ABCDEFGHI')
+            ->setLength(6)
+            ->generate(1, 100, true);
 
-    //     $this->assertIsArray($codes);
-    // }
+        $this->assertIsArray($codes);
+    }
 
-    // /** @test */
-    // public function it_returns_string_if_no_end_provided()
-    // {
-    //     $code = (new UniqueCodes())
-    //         ->setPrime(17)
-    //         ->setMaxPrime(101)
-    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //         ->setLength(6)
-    //         ->generate(100);
+    /** @test */
+    public function it_returns_string_if_no_end_provided()
+    {
+        $code = (new UniqueCodes())
+            ->setObfuscatingPrime(191)
+            ->setMaxPrime(101)
+            ->setCharacters('ABCDEFGHI')
+            ->setLength(6)
+            ->generate(100);
 
-    //     $this->assertIsString($code);
-    // }
+        $this->assertIsString($code);
+    }
 
-    // /** @test */
-    // public function it_generates_unique_codes()
-    // {
-    //     $codes = iterator_to_array(
-    //         (new UniqueCodes())
-    //             ->setPrime(17)
-    //             ->setMaxPrime(101)
-    //             ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //             ->setLength(6)
-    //             ->generate(1, 100)
-    //     );
+    /** @test */
+    public function it_generates_unique_codes_within_range()
+    {
+        $codes = iterator_to_array(
+            (new UniqueCodes())
+                ->setObfuscatingPrime(191)
+                ->setMaxPrime(101)
+                ->setCharacters('ABCDEFGHI')
+                ->setLength(6)
+                ->generate(25, 75)
+        );
 
-    //     $this->assertCount(100, $codes);
-    //     $this->assertCount(100, array_unique($codes));
+        $this->assertCount(51, $codes);
+        $this->assertCount(51, array_unique($codes));
+    }
 
-    //     $codes = iterator_to_array(
-    //         (new UniqueCodes())
-    //             ->setPrime(30983)
-    //             ->setMaxPrime(98893)
-    //             ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //             ->setLength(6)
-    //             ->generate(1, 98892)
-    //     );
+    /** @test */
+    public function it_generates_one_unique_code()
+    {
+        $codes = iterator_to_array(
+            (new UniqueCodes())
+                ->setObfuscatingPrime(191)
+                ->setMaxPrime(101)
+                ->setCharacters('ABCDEFGHI')
+                ->setLength(6)
+                ->generate(25, 25)
+        );
 
-    //     $this->assertCount(98892, $codes);
-    //     $this->assertCount(98892, array_unique($codes));
+        $this->assertCount(1, $codes);
+        $this->assertCount(1, array_unique($codes));
+    }
 
-    //     $codes = iterator_to_array(
-    //         (new UniqueCodes())
-    //             ->setPrime(13)
-    //             ->setMaxPrime(113)
-    //             ->setCharacters('ABCDE')
-    //             ->setLength(4)
-    //             ->generate(1, 112)
-    //     );
+    /** @test */
+    public function it_generates_codes_that_only_contain_characters_from_specified_character_list()
+    {
+        $codes = iterator_to_array(
+            (new UniqueCodes())
+                ->setObfuscatingPrime(191)
+                ->setMaxPrime(101)
+                ->setCharacters($characters = 'ABCDEFG')
+                ->setLength(6)
+                ->generate(1, 100)
+        );
 
-    //     $this->assertCount(112, $codes);
-    //     $this->assertCount(112, array_unique($codes));
-    // }
+        foreach ($codes as $code) {
+            $this->assertEquals(6, strlen($code));
+            $this->assertCount(0, array_diff(str_split($code), str_split($characters)));
+        }
+    }
 
-    // /** @test */
-    // public function it_generates_unique_codes_within_range()
-    // {
-    //     $codes = iterator_to_array(
-    //         (new UniqueCodes())
-    //             ->setPrime(17)
-    //             ->setMaxPrime(101)
-    //             ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //             ->setLength(6)
-    //             ->generate(25, 75)
-    //     );
+    /** @test */
+    public function it_generates_codes_with_character_list_array()
+    {
+        $codes = iterator_to_array(
+            (new UniqueCodes())
+                ->setObfuscatingPrime(191)
+                ->setMaxPrime(101)
+                ->setCharacters($characters = ['A', 'B', 'C', 'D', 'E', 'F', 'G'])
+                ->setLength(6)
+                ->generate(1, 100)
+        );
 
-    //     $this->assertCount(51, $codes);
-    //     $this->assertCount(51, array_unique($codes));
-    // }
+        $this->assertCount(100, array_unique($codes));
 
-    // /** @test */
-    // public function it_generates_one_unique_code()
-    // {
-    //     $codes = iterator_to_array(
-    //         (new UniqueCodes())
-    //             ->setPrime(17)
-    //             ->setMaxPrime(101)
-    //             ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //             ->setLength(6)
-    //             ->generate(25, 25)
-    //     );
+        foreach ($codes as $code) {
+            $this->assertEquals(6, strlen($code));
+            $this->assertCount(0, array_diff(str_split($code), $characters));
+        }
+    }
 
-    //     $this->assertCount(1, $codes);
-    //     $this->assertCount(1, array_unique($codes));
-    // }
+    /** @test */
+    public function it_generates_codes_with_prefix()
+    {
+        $codes = iterator_to_array(
+            (new UniqueCodes())
+                ->setObfuscatingPrime(191)
+                ->setMaxPrime(101)
+                ->setCharacters('ABCDEFGHI')
+                ->setLength(6)
+                ->setPrefix('TEST')
+                ->generate(1, 100)
+        );
 
-    // /** @test */
-    // public function it_generates_codes_that_only_contain_characters_from_specified_character_list()
-    // {
-    //     $codes = iterator_to_array(
-    //         (new UniqueCodes())
-    //             ->setPrime(17)
-    //             ->setMaxPrime(101)
-    //             ->setCharacters($characters = 'ABCDEFG')
-    //             ->setLength(6)
-    //             ->generate(1, 100)
-    //     );
+        $this->assertCount(100, array_unique($codes));
 
-    //     foreach ($codes as $code) {
-    //         $this->assertEquals(6, strlen($code));
-    //         $this->assertCount(0, array_diff(str_split($code), str_split($characters)));
-    //     }
-    // }
+        foreach ($codes as $code) {
+            $this->assertEquals(10, strlen($code));
+            $this->assertEquals('TEST', substr($code, 0, 4));
+        }
+    }
 
-    // /** @test */
-    // public function it_generates_codes_with_character_list_array()
-    // {
-    //     $codes = iterator_to_array(
-    //         (new UniqueCodes())
-    //             ->setPrime(17)
-    //             ->setMaxPrime(101)
-    //             ->setCharacters($characters = ['A', 'B', 'C', 'D', 'E', 'F', 'G'])
-    //             ->setLength(6)
-    //             ->generate(1, 100)
-    //     );
+    /** @test */
+    public function it_generates_codes_with_suffix()
+    {
+        $codes = iterator_to_array(
+            (new UniqueCodes())
+                ->setObfuscatingPrime(191)
+                ->setMaxPrime(101)
+                ->setCharacters('ABCDEFGHI')
+                ->setLength(6)
+                ->setSuffix('TEST')
+                ->generate(1, 100)
+        );
 
-    //     $this->assertCount(100, array_unique($codes));
+        $this->assertCount(100, array_unique($codes));
 
-    //     foreach ($codes as $code) {
-    //         $this->assertEquals(6, strlen($code));
-    //         $this->assertCount(0, array_diff(str_split($code), $characters));
-    //     }
-    // }
+        foreach ($codes as $code) {
+            $this->assertEquals(10, strlen($code));
+            $this->assertEquals('TEST', substr($code, 6, 4));
+        }
+    }
 
-    // /** @test */
-    // public function it_generates_codes_with_prefix()
-    // {
-    //     $codes = iterator_to_array(
-    //         (new UniqueCodes())
-    //             ->setPrime(17)
-    //             ->setMaxPrime(101)
-    //             ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //             ->setLength(6)
-    //             ->setPrefix('TEST')
-    //             ->generate(1, 100)
-    //     );
+    /** @test */
+    public function it_generates_codes_with_prefix_and_suffix()
+    {
+        $codes = iterator_to_array(
+            (new UniqueCodes())
+                ->setObfuscatingPrime(191)
+                ->setMaxPrime(101)
+                ->setCharacters('ABCDEFGHI')
+                ->setLength(6)
+                ->setPrefix('PREFIX')
+                ->setSuffix('SUFFIX')
+                ->generate(1, 100)
+        );
 
-    //     $this->assertCount(100, array_unique($codes));
+        $this->assertCount(100, array_unique($codes));
 
-    //     foreach ($codes as $code) {
-    //         $this->assertEquals(10, strlen($code));
-    //         $this->assertEquals('TEST', substr($code, 0, 4));
-    //     }
-    // }
+        foreach ($codes as $code) {
+            $this->assertEquals(18, strlen($code));
+            $this->assertEquals('PREFIX', substr($code, 0, 6));
+            $this->assertEquals('SUFFIX', substr($code, 12, 6));
+        }
+    }
 
-    // /** @test */
-    // public function it_generates_codes_with_suffix()
-    // {
-    //     $codes = iterator_to_array(
-    //         (new UniqueCodes())
-    //             ->setPrime(17)
-    //             ->setMaxPrime(101)
-    //             ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //             ->setLength(6)
-    //             ->setSuffix('TEST')
-    //             ->generate(1, 100)
-    //     );
+    /** @test */
+    public function it_generates_codes_with_delimiter()
+    {
+        $codes = iterator_to_array(
+            (new UniqueCodes())
+                ->setObfuscatingPrime(191)
+                ->setMaxPrime(101)
+                ->setCharacters('ABCDEFGHI')
+                ->setLength(6)
+                ->setDelimiter('-', 3)
+                ->generate(1, 100)
+        );
 
-    //     $this->assertCount(100, array_unique($codes));
+        $this->assertCount(100, array_unique($codes));
 
-    //     foreach ($codes as $code) {
-    //         $this->assertEquals(10, strlen($code));
-    //         $this->assertEquals('TEST', substr($code, 6, 4));
-    //     }
-    // }
+        foreach ($codes as $code) {
+            $this->assertEquals(7, strlen($code));
+            $this->assertEquals('-', substr($code, 3, 1));
+        }
+    }
 
-    // /** @test */
-    // public function it_generates_codes_with_prefix_and_suffix()
-    // {
-    //     $codes = iterator_to_array(
-    //         (new UniqueCodes())
-    //             ->setPrime(17)
-    //             ->setMaxPrime(101)
-    //             ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //             ->setLength(6)
-    //             ->setPrefix('PREFIX')
-    //             ->setSuffix('SUFFIX')
-    //             ->generate(1, 100)
-    //     );
+    /** @test */
+    public function it_generates_codes_with_suffix_and_prefix_and_delimiter()
+    {
+        $codes = iterator_to_array(
+            (new UniqueCodes())
+                ->setObfuscatingPrime(191)
+                ->setMaxPrime(101)
+                ->setCharacters('ABCDEFGHI')
+                ->setLength(6)
+                ->setPrefix('PREFIX')
+                ->setSuffix('SUFFIX')
+                ->setDelimiter('-', 3)
+                ->generate(1, 100)
+        );
 
-    //     $this->assertCount(100, array_unique($codes));
+        $this->assertCount(100, array_unique($codes));
 
-    //     foreach ($codes as $code) {
-    //         $this->assertEquals(18, strlen($code));
-    //         $this->assertEquals('PREFIX', substr($code, 0, 6));
-    //         $this->assertEquals('SUFFIX', substr($code, 12, 6));
-    //     }
-    // }
+        foreach ($codes as $code) {
+            $this->assertEquals(21, strlen($code));
+            $this->assertEquals('PREFIX-', substr($code, 0, 7));
+            $this->assertEquals('-', substr($code, 10, 1));
+            $this->assertEquals('-SUFFIX', substr($code, 14, 7));
+        }
+    }
 
-    // /** @test */
-    // public function it_generates_codes_with_delimiter()
-    // {
-    //     $codes = iterator_to_array(
-    //         (new UniqueCodes())
-    //             ->setPrime(17)
-    //             ->setMaxPrime(101)
-    //             ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //             ->setLength(6)
-    //             ->setDelimiter('-', 3)
-    //             ->generate(1, 100)
-    //     );
+    /** @test */
+    public function it_throws_exception_if_obfuscating_prime_is_not_specified()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Obfuscating prime number must be specified');
 
-    //     $this->assertCount(100, array_unique($codes));
+        (new UniqueCodes())
+            ->setMaxPrime(101)
+            ->setCharacters('ABCDEFGHI')
+            ->setLength(6)
+            ->generate(1, 100);
+    }
 
-    //     foreach ($codes as $code) {
-    //         $this->assertEquals(7, strlen($code));
-    //         $this->assertEquals('-', substr($code, 3, 1));
-    //     }
-    // }
+    /** @test */
+    public function it_throws_exception_if_max_prime_is_not_specified()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Max prime number must be specified');
 
-    // /** @test */
-    // public function it_generates_codes_with_suffix_and_prefix_and_delimiter()
-    // {
-    //     $codes = iterator_to_array(
-    //         (new UniqueCodes())
-    //             ->setPrime(17)
-    //             ->setMaxPrime(101)
-    //             ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //             ->setLength(6)
-    //             ->setPrefix('PREFIX')
-    //             ->setSuffix('SUFFIX')
-    //             ->setDelimiter('-', 3)
-    //             ->generate(1, 100)
-    //     );
+        (new UniqueCodes())
+            ->setObfuscatingPrime(191)
+            ->setCharacters('ABCDEFGHI')
+            ->setLength(6)
+            ->generate(1, 100);
+    }
 
-    //     $this->assertCount(100, array_unique($codes));
+    /** @test */
+    public function it_throws_exception_if_characters_are_not_specified()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Character list must be specified');
 
-    //     foreach ($codes as $code) {
-    //         $this->assertEquals(21, strlen($code));
-    //         $this->assertEquals('PREFIX-', substr($code, 0, 7));
-    //         $this->assertEquals('-', substr($code, 10, 1));
-    //         $this->assertEquals('-SUFFIX', substr($code, 14, 7));
-    //     }
-    // }
+        (new UniqueCodes())
+            ->setObfuscatingPrime(191)
+            ->setMaxPrime(101)
+            ->setLength(6)
+            ->generate(1, 100);
+    }
 
-    // /** @test */
-    // public function it_throws_exception_if_prime_is_not_specified()
-    // {
-    //     $this->expectException(RuntimeException::class);
-    //     $this->expectExceptionMessage('Prime number must be specified');
+    /** @test */
+    public function it_throws_exception_if_length_is_not_specified()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Length must be specified');
 
-    //     (new UniqueCodes())
-    //         ->setMaxPrime(101)
-    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //         ->setLength(6)
-    //         ->generate(1, 100);
-    // }
+        (new UniqueCodes())
+            ->setObfuscatingPrime(191)
+            ->setMaxPrime(101)
+            ->setCharacters('ABCDEFGHI')
+            ->generate(1, 100);
+    }
 
-    // /** @test */
-    // public function it_throws_exception_if_max_prime_is_not_specified()
-    // {
-    //     $this->expectException(RuntimeException::class);
-    //     $this->expectExceptionMessage('Max prime number must be specified');
+    /** @test */
+    public function it_throws_exception_if_obfuscating_prime_number_is_smaller_than_max_prime_number()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Obfuscating prime number must be larger than the max prime number');
 
-    //     (new UniqueCodes())
-    //         ->setPrime(17)
-    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //         ->setLength(6)
-    //         ->generate(1, 100);
-    // }
+        (new UniqueCodes())
+            ->setObfuscatingPrime(17)
+            ->setMaxPrime(101)
+            ->setCharacters('ABCDEFGHI')
+            ->setLength(6)
+            ->generate(1, 100);
+    }
 
-    // /** @test */
-    // public function it_throws_exception_if_characters_are_not_specified()
-    // {
-    //     $this->expectException(RuntimeException::class);
-    //     $this->expectExceptionMessage('Character list must be specified');
+    /** @test */
+    public function it_throws_exception_if_obfuscating_prime_number_is_equal_to_max_prime_number()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Obfuscating prime number must be larger than the max prime number');
 
-    //     (new UniqueCodes())
-    //         ->setPrime(17)
-    //         ->setMaxPrime(101)
-    //         ->setLength(6)
-    //         ->generate(1, 100);
-    // }
+        (new UniqueCodes())
+            ->setObfuscatingPrime(101)
+            ->setMaxPrime(101)
+            ->setCharacters('ABCDEFGHI')
+            ->setLength(6)
+            ->generate(1, 100);
+    }
 
-    // /** @test */
-    // public function it_throws_exception_if_length_is_not_specified()
-    // {
-    //     $this->expectException(RuntimeException::class);
-    //     $this->expectExceptionMessage('Length must be specified');
+    /** @test */
+    public function it_throws_exception_if_character_list_contains_duplicates()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The character list can not contain duplicates');
 
-    //     (new UniqueCodes())
-    //         ->setPrime(17)
-    //         ->setMaxPrime(101)
-    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //         ->generate(1, 100);
-    // }
+        (new UniqueCodes())
+            ->setObfuscatingPrime(191)
+            ->setMaxPrime(101)
+            ->setCharacters('ABCDEFGHIA')
+            ->setLength(6)
+            ->generate(1, 100);
+    }
 
-    // /** @test */
-    // public function it_throws_exception_if_prime_number_is_bigger_than_max_prime_number()
-    // {
-    //     $this->expectException(RuntimeException::class);
-    //     $this->expectExceptionMessage('Prime number must be smaller than the max prime number');
+    /** @test */
+    public function it_throws_exception_if_max_prime_number_is_too_big_for_the_specified_character_list_and_code_length()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The length of the code is too short or the character list is too small to create the number of unique codes equal to the max prime number');
 
-    //     (new UniqueCodes())
-    //         ->setPrime(101)
-    //         ->setMaxPrime(17)
-    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //         ->setLength(6)
-    //         ->generate(1, 100);
-    // }
+        (new UniqueCodes())
+            ->setObfuscatingPrime(191)
+            ->setMaxPrime(101)
+            ->setCharacters('ABCD')
+            ->setLength(3)
+            ->generate(1, 100);
+    }
 
-    // /** @test */
-    // public function it_throws_exception_if_prime_number_is_equal_to_max_prime_number()
-    // {
-    //     $this->expectException(RuntimeException::class);
-    //     $this->expectExceptionMessage('Prime number must be smaller than the max prime number');
+    /** @test */
+    public function it_throws_exception_if_start_is_less_than_zero()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The start number must be bigger than zero');
 
-    //     (new UniqueCodes())
-    //         ->setPrime(101)
-    //         ->setMaxPrime(101)
-    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //         ->setLength(6)
-    //         ->generate(1, 100);
-    // }
+        (new UniqueCodes())
+            ->setObfuscatingPrime(191)
+            ->setMaxPrime(101)
+            ->setCharacters('ABCDEFGHI')
+            ->setLength(6)
+            ->generate(-1, 100);
+    }
 
-    // /** @test */
-    // public function it_throws_exception_if_size_of_character_list_is_smaller_than_specified_code_length()
-    // {
-    //     $this->expectException(RuntimeException::class);
-    //     $this->expectExceptionMessage('The size of the character list must be bigger or equal to the length of the code');
+    /** @test */
+    public function it_throws_exception_if_start_equals_zero()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The start number must be bigger than zero');
 
-    //     (new UniqueCodes())
-    //         ->setPrime(17)
-    //         ->setMaxPrime(101)
-    //         ->setCharacters('LQJCK')
-    //         ->setLength(6)
-    //         ->generate(1, 100);
-    // }
+        (new UniqueCodes())
+            ->setObfuscatingPrime(191)
+            ->setMaxPrime(101)
+            ->setCharacters('ABCDEFGHI')
+            ->setLength(6)
+            ->generate(0, 100);
+    }
 
-    // /** @test */
-    // public function it_throws_exception_if_size_of_character_list_equals_specified_code_length()
-    // {
-    //     $this->expectException(RuntimeException::class);
-    //     $this->expectExceptionMessage('The size of the character list must be bigger or equal to the length of the code');
+    /** @test */
+    public function it_throws_exception_if_end_is_bigger_than_max_prime_number()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The end number can not be bigger or equal to the max prime number');
 
-    //     (new UniqueCodes())
-    //         ->setPrime(17)
-    //         ->setMaxPrime(101)
-    //         ->setCharacters('LQJCKZ')
-    //         ->setLength(6)
-    //         ->generate(1, 100);
-    // }
+        (new UniqueCodes())
+            ->setObfuscatingPrime(191)
+            ->setMaxPrime(101)
+            ->setCharacters('ABCDEFGHI')
+            ->setLength(6)
+            ->generate(50, 150);
+    }
 
-    // /** @test */
-    // public function it_throws_exception_if_character_list_contains_duplicates()
-    // {
-    //     $this->expectException(RuntimeException::class);
-    //     $this->expectExceptionMessage('The character list can not contain duplicates');
+    /** @test */
+    public function it_throws_exception_if_end_equals_max_prime_number()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The end number can not be bigger or equal to the max prime number');
 
-    //     (new UniqueCodes())
-    //         ->setPrime(17)
-    //         ->setMaxPrime(101)
-    //         ->setCharacters('LQJCKZL')
-    //         ->setLength(6)
-    //         ->generate(1, 100);
-    // }
-
-    // /** @test */
-    // public function it_throws_exception_if_max_prime_number_is_too_big_for_the_specified_character_list_and_code_length()
-    // {
-    //     $this->expectException(RuntimeException::class);
-    //     $this->expectExceptionMessage('The length of the code is too short or the character list is too small to create the number of unique codes equal to the max prime number');
-
-    //     (new UniqueCodes())
-    //         ->setPrime(17)
-    //         ->setMaxPrime(101)
-    //         ->setCharacters('LQJC')
-    //         ->setLength(3)
-    //         ->generate(1, 100);
-    // }
-
-    // /** @test */
-    // public function it_throws_exception_if_start_is_less_than_zero()
-    // {
-    //     $this->expectException(RuntimeException::class);
-    //     $this->expectExceptionMessage('The start number must be bigger than zero');
-
-    //     (new UniqueCodes())
-    //         ->setPrime(17)
-    //         ->setMaxPrime(101)
-    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //         ->setLength(6)
-    //         ->generate(-1, 100);
-    // }
-
-    // /** @test */
-    // public function it_throws_exception_if_start_equals_zero()
-    // {
-    //     $this->expectException(RuntimeException::class);
-    //     $this->expectExceptionMessage('The start number must be bigger than zero');
-
-    //     (new UniqueCodes())
-    //         ->setPrime(17)
-    //         ->setMaxPrime(101)
-    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //         ->setLength(6)
-    //         ->generate(0, 100);
-    // }
-
-    // /** @test */
-    // public function it_throws_exception_if_end_is_bigger_than_max_prime_number()
-    // {
-    //     $this->expectException(RuntimeException::class);
-    //     $this->expectExceptionMessage('The end number can not be bigger or equal to the max prime number');
-
-    //     (new UniqueCodes())
-    //         ->setPrime(17)
-    //         ->setMaxPrime(101)
-    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //         ->setLength(6)
-    //         ->generate(50, 150);
-    // }
-
-    // /** @test */
-    // public function it_throws_exception_if_end_equals_max_prime_number()
-    // {
-    //     $this->expectException(RuntimeException::class);
-    //     $this->expectExceptionMessage('The end number can not be bigger or equal to the max prime number');
-
-    //     (new UniqueCodes())
-    //         ->setPrime(17)
-    //         ->setMaxPrime(101)
-    //         ->setCharacters('LQJCKZM4WDPT69S7XRGANY23VBH58F1')
-    //         ->setLength(6)
-    //         ->generate(50, 101);
-    // }
+        (new UniqueCodes())
+            ->setObfuscatingPrime(191)
+            ->setMaxPrime(101)
+            ->setCharacters('ABCDEFGHI')
+            ->setLength(6)
+            ->generate(50, 101);
+    }
 }

--- a/tests/UniqueCodesTest.php
+++ b/tests/UniqueCodesTest.php
@@ -44,6 +44,7 @@ class UniqueCodesTest extends TestCase
             [30983, 98893, 3925, 4, '123456ABCDEFGH'],
             [495563, 968197, 86214, 6, 'ABCDEFGHI'],
             [1340021, 6824473, 46234, 8, 'ABCDEF'],
+            [7230323, 9006077, 4263725, 6, 'LQJCKZMWDPTSXRGANYVBHF']
         ];
     }
 


### PR DESCRIPTION
- rename `setPrime` method to `setObfuscatingPrime`
- obfuscating prime number must be larger than max prime number
- remove the requirement that there must be more characters than the code length
- add unit tests for the encoding process
- add unit tests for the obfuscation process